### PR TITLE
Adjust week 19 to accommodate Capstone presentations.

### DIFF
--- a/week19/weekly_overview.md
+++ b/week19/weekly_overview.md
@@ -37,10 +37,11 @@ In Week 19 we will continue the two week Ember.js project. We will focus on lear
 
 ### Thursday
 
-| Time             | Topic                                                    |
-|:----------------:|:--------------------------------------------------------:|
-| **9:00 - 9:15**  | Stand Up                                                 |
-| **9:15 - 5:00**  | [Ember Project](ember-project.md)         |
+| Time             | Topic                                                            |
+|:----------------:|:----------------------------------------------------------------:|
+| **9:00 - 9:15**  | Stand Up                                                         |
+| **9:15 - 3:30**  | [Ember Project](ember-project.md)                                |
+| **3:30 - 5:00**  | [Capstone Project](../week18/thursday/capstone.md) Presentations |
 
 ### Friday
 


### PR DESCRIPTION
@bookis - does this time work for the students to do Capstone presentations? I want it to be Friday, but it seems like it would be too much with Capstone presentations, Ember presentations, and Retro. Thoughts? Should it be next week?
