### PR TITLE
Fixes typo in DNS configuration link

### DIFF
--- a/week21/weekly_overview.md
+++ b/week21/weekly_overview.md
@@ -53,7 +53,7 @@ the project is on track, review stories, and consult on any problems.
 
 | Time            | Topic        |
 |:----------------|:-------------|
-| **9:00 - 10:00**  | [DNS Configuration](wednesday/dns-configuration.md)|
+| **9:00 - 10:00**  | [DNS Configuration](friday/dns-configuration.md)|
 | **10:00 - 5:00**  | [Capstone Project Time](../capstone/capstone.md)|
 
 * Sponsor interviews from 12-5


### PR DESCRIPTION
The DNS configuration link was navigating to the Wednesday folder instead of Friday
