### PR TITLE
Update URL for Homebrew install script.

### DIFF
--- a/week01/monday/installfest.md
+++ b/week01/monday/installfest.md
@@ -36,7 +36,7 @@ Homebrew
 Type this into your terminal:
 
 ```
-ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 
 You may need to enter your computer password if you have one set.


### PR DESCRIPTION
```
$ ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
Thanks!
```