### PR TITLE
Change Fixnum to Integer

### DIFF
--- a/archive/topic_resources/problem-solving-interview/ada-101.md
+++ b/archive/topic_resources/problem-solving-interview/ada-101.md
@@ -1,4 +1,10 @@
 # Problem Solving Interview: Working with a Ruby REPL
+[This video](https://adaacademy.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=4df0c8ab-64fc-4186-a9e2-a8c4014a4b4b) is part of the Ada Admissions' process. The following notes go with the video. 
+
+## Notes
+- Although the video calls out `Fixnum`, it has been deprecated since the time the video was recorded. Please use `Integer` instead of `Fixnum`.
+- The following are verbatim notes that go with the video linked above.
+
 Hi! My name is <3Jeremy and I'm an instructor at Ada. This video is part of the admissions process. Together we are going to look at some concepts common to many programming languages. My job in this process is to explain a few key concepts, with examples and guidance. At the end, we'll write a program together.
 
 Your job during this video is to follow along. I recommend watching this video at least twice. The first time, just watch and maybe take a few notes. After the first viewing, take a break. When you sit down to watch the video a second time, be ready to try doing things along with me. Open a web browser like __Google Chrome__ or __Mozilla Firefox__ and go to this URL: https://repl.it/languages/ruby
@@ -15,21 +21,21 @@ Ruby is pretty smart and understands lots of things in a way similar to how peop
 ### Values
 A _value_ can be most anything, like a name (`"Jeremy"`), a whole number (`5000`), or a decimal number (`3.14`). We use _values_ in conjuction with _commands_ to give Ruby instructions on what to do. We'll talk more about _commands_ in a bit.
 
-Every _value_ can be described by a _type_. There are lots of _types_ in Ruby, and we are going to talk about three of them today: `String`, `Fixnum`, and `Float`.
+Every _value_ can be described by a _type_. There are lots of _types_ in Ruby, and we are going to talk about three of them today: `String`, `Integer` (was `Fixnum`), and `Float`.
 
 ### Types
 A `String` is any sequence of letters and/or numbers enclosed in either single (`'`) or double (`"`) quotes. `"Elephant Hotdog"` is a `String`, and so is `'42'`. Most of the time, you can use either single or double quotes to create a _string value_.
 
-A `Fixnum` is a whole number expressed without a decimal. There's a couple ways to create _fixnum values_, but the most common is to type out the number. `1` is a `Fixnum`, and so is `23` and `-4500`.
+An `Integer` is a whole number expressed without a decimal. There's a couple ways to create _integer values_, but the most common is to type out the number. `1` is an `Integer`, and so is `23` and `-4500`.
 
 #### Question: How are `42` and `"42"` different?
 
-A `Float` is a number expressed __with__ a decimal value. There are important distinctions between doing math in Ruby with _fixnum_ and _float values_, but for today, we will focus on _float values_ being expressed by typing a number with a decimal like `3.14`, `0.05`, and `1000.2387`. In later lessons, we will explore why `Float` and `Fixnum` are different _types_ and how those differences affect our programs.
+A `Float` is a number expressed __with__ a decimal value. There are important distinctions between doing math in Ruby with _integer_ and _float values_, but for today, we will focus on _float values_ being expressed by typing a number with a decimal like `3.14`, `0.05`, and `1000.2387`. In later lessons, we will explore why `Float` and `Integer` are different _types_ and how those differences affect our programs.
 
 ### Commands
 Ruby has many kinds of commands built into its _core library_. We can utilize these _commands_ along with _values_ to give Ruby instructions about what to do. For this lecture, we are going to cover a handful of commands:
 
-- `Fixnum` & `Float` Commands:
+- `Integer` & `Float` Commands:
   - `+`
   - `-`
   - `*`


### PR DESCRIPTION
Since Fixnum is deprecated in Ruby 2.4 and onwards, encourage admissions' code challenge to leverage Integer instead of Fixnum.